### PR TITLE
fix(header,footer): remove fragment loading antipattern

### DIFF
--- a/.hlxignore
+++ b/.hlxignore
@@ -5,4 +5,3 @@ LICENSE
 package.json
 package-lock.json
 test/*
-*.plain.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,11 @@ Every PR that changes code served by EDS (JS, CSS, HTML, blocks) **must** includ
 
 ```
 Test URLs:
-- Before: https://main--grounded--benpeter.aem.page/
-- After: https://<branch>--grounded--benpeter.aem.page/<path>
+- Before: https://main--grounded--benpeter.aem.live/
+- After: https://<branch>--grounded--benpeter.aem.live/<path>
 ```
 
-**Branch name in URLs**: Slashes in git branch names become dashes in EDS preview URLs. `nefario/implement-foo` → `nefario-implement-foo--grounded--benpeter.aem.page`.
+**Branch name in URLs**: Slashes in git branch names become dashes in EDS preview URLs. `nefario/implement-foo` → `nefario-implement-foo--grounded--benpeter.aem.live`.
 
 The `<path>` should point to a page that demonstrates the change. This is required by the EDS review process and the PR template.
 

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -1,20 +1,29 @@
-import { getMetadata } from '../../scripts/aem.js';
-import { loadFragment } from '../fragment/fragment.js';
-
 /**
  * loads and decorates the footer
  * @param {Element} block The footer block element
  */
-export default async function decorate(block) {
-  // load footer as fragment
-  const footerMeta = getMetadata('footer');
-  const footerPath = footerMeta ? new URL(footerMeta, window.location).pathname : '/footer';
-  const fragment = await loadFragment(footerPath);
-
-  // decorate footer DOM
-  block.textContent = '';
+export default function decorate(block) {
   const footer = document.createElement('div');
-  while (fragment.firstElementChild) footer.append(fragment.firstElementChild);
+  const p = document.createElement('p');
 
+  const author = document.createElement('a');
+  author.href = 'https://www.linkedin.com/in/benpeter/';
+  author.target = '_blank';
+  author.rel = 'noopener';
+  author.setAttribute('aria-label', 'Ben Peter on LinkedIn (opens in new tab)');
+  author.textContent = 'Ben Peter';
+
+  const legal = document.createElement('a');
+  legal.href = '/legal';
+  legal.textContent = 'Legal Notice';
+
+  const privacy = document.createElement('a');
+  privacy.href = '/privacy';
+  privacy.textContent = 'Privacy Policy';
+
+  p.append('\u00A9\u00A02026\u00A0', author, ' \u00B7 ', legal, ' \u00B7 ', privacy);
+  footer.append(p);
+
+  block.textContent = '';
   block.append(footer);
 }

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -9,9 +9,6 @@
  * Design spec: docs/design-decisions/DDD-002-header.md
  */
 
-import { getMetadata } from '../../scripts/aem.js';
-import { loadFragment } from '../fragment/fragment.js';
-
 /**
  * Creates an inline SVG filter for the text corruption effect.
  * Uses feTurbulence + feDisplacementMap to produce organic warping.
@@ -51,23 +48,8 @@ function createCorruptionFilter() {
  * loads and decorates the header block
  * @param {Element} block The header block element
  */
-export default async function decorate(block) {
-  const navMeta = getMetadata('nav');
-  const navPath = navMeta ? new URL(navMeta, window.location).pathname : '/nav';
-  const fragment = await loadFragment(navPath);
-
-  // Extract content from nav fragment, with fallbacks
-  const linkEl = fragment?.querySelector('a[href="/"]');
-  const emEl = fragment?.querySelector('em');
-  const logoText = linkEl?.textContent?.trim() || 'Mostly Hallucinations';
-  const taglineText = emEl?.textContent?.trim() || 'Generated, meet grounded.';
-
-  // Split into "Mostly" and "Hallucinations" on the first space
-  const spaceIdx = logoText.indexOf(' ');
-  const wordMostly = spaceIdx > 0 ? logoText.substring(0, spaceIdx) : 'Mostly';
-  const wordHallucinations = spaceIdx > 0 ? logoText.substring(spaceIdx + 1) : 'Hallucinations';
-
-  // Build DOM fresh -- do not move fragment nodes (avoids decorateButtons class contamination)
+export default function decorate(block) {
+  // Build DOM fresh
   const nav = document.createElement('nav');
   nav.id = 'nav';
   nav.setAttribute('aria-label', 'Site');
@@ -82,17 +64,17 @@ export default async function decorate(block) {
 
   const mostlySpan = document.createElement('span');
   mostlySpan.className = 'logo-word-mostly';
-  mostlySpan.textContent = wordMostly;
+  mostlySpan.textContent = 'Mostly';
 
   const hallSpan = document.createElement('span');
   hallSpan.className = 'logo-word-hallucinations';
-  hallSpan.textContent = wordHallucinations;
+  hallSpan.textContent = 'Hallucinations';
 
   logoSpan.append(mostlySpan, hallSpan);
 
   const tagline = document.createElement('span');
   tagline.className = 'tagline';
-  tagline.textContent = taglineText;
+  tagline.textContent = 'Generated, meet grounded.';
 
   link.append(logoSpan, tagline);
   nav.append(link);

--- a/footer.plain.html
+++ b/footer.plain.html
@@ -1,5 +1,0 @@
-<div>
-  <p>
-    &copy;&nbsp;2026&nbsp;<a href="https://www.linkedin.com/in/benpeter/" target="_blank" rel="noopener" aria-label="Ben Peter on LinkedIn (opens in new tab)">Ben Peter</a> · <a href="/legal">Legal Notice</a> · <a href="/privacy">Privacy Policy</a>
-  </p>
-</div>

--- a/nav.plain.html
+++ b/nav.plain.html
@@ -1,4 +1,0 @@
-<div>
-  <p><a href="/">Mostly Hallucinations</a></p>
-  <p><em>Generated, meet grounded.</em></p>
-</div>


### PR DESCRIPTION
## Summary

- Removed `loadFragment()` / `getMetadata()` calls from header and footer blocks — they fetched CMS pages (`/nav`, `/footer`) that don't exist, causing 404 requests on live and a footer crash (no null guard)
- Inlined static content directly: logo text, tagline, and footer copyright/links
- Deleted `nav.plain.html` and `footer.plain.html` stub files and the `*.plain.html` hlxignore rule they required

## Test plan

- [ ] Header renders logo + tagline with corruption filter
- [ ] Footer renders `© 2026 Ben Peter · Legal Notice · Privacy Policy`
- [ ] No 404 requests for `/nav.plain.html` or `/footer.plain.html` in network tab
- [ ] `npm run lint` passes

Test URLs:
- Before: https://main--grounded--benpeter.aem.live/
- After: https://fix-remove-fragment-antipattern--grounded--benpeter.aem.live/

🤖 Generated with [Claude Code](https://claude.com/claude-code)