### PR TITLE
fix: add top margin between header and first content section

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -172,7 +172,7 @@ main > .section {
 }
 
 main > .section:first-of-type {
-  margin-block-start: 0;
+  margin-block-start: var(--section-spacing);
 }
 
 /* Outer tier: layout max on every section container */


### PR DESCRIPTION
## Summary
- The first section's `margin-block-start` was explicitly set to `0`, causing the post index to sit flush against the header with no spacing
- Changed to `var(--section-spacing)` (48px) for proper breathing room

## Test URLs
- Before: https://main--grounded--benpeter.aem.live/
- After: https://fix-post-index-header-spacing--grounded--benpeter.aem.live/

## Test plan
- [ ] Verify spacing between header and post index on homepage
- [ ] Check mobile, tablet, and desktop breakpoints
- [ ] Verify post detail pages still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)