### PR TITLE
infra: Cloudflare custom domain for mostly-hallucinations.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ helix-importer-ui
 # Claude Code local config (not committed)
 CLAUDE.local.md
 
+# Terraform state (contains secrets)
+infra/.terraform/
+infra/*.tfstate
+infra/*.tfstate.backup
+# infra/.terraform.lock.hcl is committed (provider version pinning)
+infra/*.tfvars.local
+
 # Ensure these files are tracked
 !CLAUDE.md
 !AGENTS.md

--- a/.hlxignore
+++ b/.hlxignore
@@ -5,3 +5,5 @@ LICENSE
 package.json
 package-lock.json
 test/*
+infra/*
+worker/*

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/cloudflare/cloudflare" {
+  version     = "5.18.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:2FKT5YVLuHLmv7BnFxDC3UtipD3hSSrb0iJ9Ei2C/ks=",
+    "zh:47e7bdfd8eddd2685f383269c0b6936ef62edd6d8383c8d7757b0cce0a689737",
+    "zh:aa23eb6aa128667883cabc449ceca4072d0181f574cd727e08ebd6d69a4bfd48",
+    "zh:c3da673e05d3bd933c82e2b6ba0f85aa23c5e24fadd3932f7c066314feeb65a3",
+    "zh:c59f07c017fc78b79e80554a0737c9db2a2e681c3e46ff637942d28d1f1a3924",
+    "zh:d559074612835a37fa684d8d7d0cf68911487b71f4067acc59069cb00bb8baf0",
+    "zh:e12290a4eda757c183a4258230245dd170f0def389c37eb771db144ce3b382dd",
+    "zh:ed47e484432ba1bbbb4802061f395ebd253ae8e20be9b72552d3d830fd2ca268",
+    "zh:f35e08d468408697b3e7c4a7f548b874141ac8f8d395ab8edded322201cc7047",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,72 @@
+# ---------------------------------------------------------------------------
+# DNS
+# ---------------------------------------------------------------------------
+
+# Apex domain — Cloudflare CNAME-flattens automatically at the root
+resource "cloudflare_dns_record" "apex" {
+  zone_id = var.zone_id
+  name    = var.domain
+  type    = "CNAME"
+  content = var.origin_hostname
+  ttl     = 1 # 1 = automatic (required when proxied)
+  proxied = true
+}
+
+# www — proxied so the Worker can intercept and redirect to apex
+resource "cloudflare_dns_record" "www" {
+  zone_id = var.zone_id
+  name    = "www.${var.domain}"
+  type    = "CNAME"
+  content = var.origin_hostname
+  ttl     = 1
+  proxied = true
+}
+
+# ---------------------------------------------------------------------------
+# Zone settings
+# ---------------------------------------------------------------------------
+
+# Full: Cloudflare <-> origin is encrypted, but origin cert hostname
+# (*.aem.live) is not validated against our domain. This is correct —
+# Fastly's cert covers *.aem.live, not mostly-hallucinations.com.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = var.zone_id
+  setting_id = "ssl"
+  value      = "full"
+}
+
+resource "cloudflare_zone_setting" "always_use_https" {
+  zone_id    = var.zone_id
+  setting_id = "always_use_https"
+  value      = "on"
+}
+
+resource "cloudflare_zone_setting" "min_tls_version" {
+  zone_id    = var.zone_id
+  setting_id = "min_tls_version"
+  value      = "1.2"
+}
+
+resource "cloudflare_zone_setting" "tls_1_3" {
+  zone_id    = var.zone_id
+  setting_id = "tls_1_3"
+  value      = "zrt"
+}
+
+resource "cloudflare_zone_setting" "automatic_https_rewrites" {
+  zone_id    = var.zone_id
+  setting_id = "automatic_https_rewrites"
+  value      = "on"
+}
+
+# Respect origin Cache-Control headers — EDS sets correct TTLs per content type
+resource "cloudflare_zone_setting" "browser_cache_ttl" {
+  zone_id    = var.zone_id
+  setting_id = "browser_cache_ttl"
+  value      = 0
+}
+
+# ---------------------------------------------------------------------------
+# Redirect: www -> apex (301)
+# Handled in the Worker (worker/index.mjs) — no separate ruleset needed.
+# ---------------------------------------------------------------------------

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,13 @@
+data "cloudflare_zone" "main" {
+  zone_id = var.zone_id
+}
+
+output "nameservers" {
+  description = "Set these nameservers at dd24"
+  value       = data.cloudflare_zone.main.name_servers
+}
+
+output "worker_name" {
+  description = "Deployed worker name"
+  value       = cloudflare_workers_script.aem_prod.script_name
+}

--- a/infra/provider.tf
+++ b/infra/provider.tf
@@ -1,0 +1,3 @@
+# Reads CLOUDFLARE_API_TOKEN from environment.
+# Never hardcode the token.
+provider "cloudflare" {}

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,6 @@
+domain          = "mostly-hallucinations.com"
+origin_hostname = "main--grounded--benpeter.aem.live"
+
+# zone_id and account_id: set via environment variables
+#   export TF_VAR_zone_id=<value>
+#   export TF_VAR_account_id=<value>

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,23 @@
+variable "account_id" {
+  description = "Cloudflare account ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "zone_id" {
+  description = "Cloudflare zone ID for mostly-hallucinations.com"
+  type        = string
+  sensitive   = true
+}
+
+variable "domain" {
+  description = "Apex domain name"
+  type        = string
+  default     = "mostly-hallucinations.com"
+}
+
+variable "origin_hostname" {
+  description = "AEM EDS origin hostname"
+  type        = string
+  default     = "main--grounded--benpeter.aem.live"
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/infra/worker.tf
+++ b/infra/worker.tf
@@ -1,0 +1,37 @@
+# ---------------------------------------------------------------------------
+# AEM EDS Cloudflare Worker
+# Source: https://github.com/adobe/aem-cloudflare-prod-worker
+# ---------------------------------------------------------------------------
+
+resource "cloudflare_workers_script" "aem_prod" {
+  account_id  = var.account_id
+  script_name = "grounded-aem-prod"
+
+  content     = file("${path.module}/../worker/index.mjs")
+  main_module = "index.mjs"
+
+  bindings = [
+    {
+      name = "ORIGIN_HOSTNAME"
+      type = "plain_text"
+      text = var.origin_hostname
+    },
+    {
+      name = "PUSH_INVALIDATION"
+      type = "plain_text"
+      text = "enabled"
+    },
+  ]
+}
+
+resource "cloudflare_workers_route" "apex" {
+  zone_id = var.zone_id
+  pattern = "${var.domain}/*"
+  script  = cloudflare_workers_script.aem_prod.script_name
+}
+
+resource "cloudflare_workers_route" "www" {
+  zone_id = var.zone_id
+  pattern = "www.${var.domain}/*"
+  script  = cloudflare_workers_script.aem_prod.script_name
+}

--- a/worker/index.mjs
+++ b/worker/index.mjs
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2022 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// tva
+// Pinned from adobe/aem-cloudflare-prod-worker (2026-03-14)
+// https://github.com/adobe/aem-cloudflare-prod-worker/blob/main/src/index.mjs
+
+'use strict';
+
+const getExtension = (path) => {
+  const basename = path.split('/').pop();
+  const pos = basename.lastIndexOf('.');
+  return (basename === '' || pos < 1) ? '' : basename.slice(pos + 1);
+};
+
+const isMediaRequest = (url) => /\/media_[0-9a-f]{40,}[/a-zA-Z0-9_-]*\.[0-9a-z]+$/.test(url.pathname);
+const isRUMRequest = (url) => /\/\.(rum|optel)\/.*/.test(url.pathname);
+
+
+const handleRequest = async (request, env, ctx) => {
+  const url = new URL(request.url);
+  if (url.port) {
+    // Cloudflare opens a couple more ports than 443, so we redirect visitors
+    // to the default port to avoid confusion.
+    // https://developers.cloudflare.com/fundamentals/reference/network-ports/#network-ports-compatible-with-cloudflares-proxy
+    const redirectTo = new URL(request.url);
+    redirectTo.port = '';
+    return new Response('Moved permanently to ' + redirectTo.href, {
+      status: 301,
+      headers: {
+        location: redirectTo.href
+      }
+    });
+  }
+
+  // www -> apex redirect (301)
+  if (url.hostname.startsWith('www.')) {
+    url.hostname = url.hostname.slice(4);
+    return new Response(null, {
+      status: 301,
+      headers: { location: url.toString() },
+    });
+  }
+
+  if (url.pathname.startsWith('/drafts/')) {
+    return new Response('Not Found', { status: 404 });
+  }
+
+  if(isRUMRequest(url)) {
+    // only allow GET, POST, OPTIONS
+    if(!['GET', 'POST', 'OPTIONS'].includes(request.method)) {
+      return new Response('Method Not Allowed', { status: 405 });
+    }
+  }
+
+  const extension = getExtension(url.pathname);
+
+  // remember original search params
+  const savedSearch = url.search;
+
+  // sanitize search params
+  const { searchParams } = url;
+  if (isMediaRequest(url)) {
+    for (const [key] of searchParams.entries()) {
+      if (!['format', 'height', 'optimize', 'width'].includes(key)) {
+        searchParams.delete(key);
+      }
+    }
+  } else if (extension === 'json') {
+    for (const [key] of searchParams.entries()) {
+      if (!['limit', 'offset', 'sheet'].includes(key)) {
+        searchParams.delete(key);
+      }
+    }
+  } else {
+    // neither media nor json request: strip search params
+    url.search = '';
+  }
+  searchParams.sort();
+
+  url.hostname = env.ORIGIN_HOSTNAME;
+  if (!url.origin.match(/^https:\/\/main--.*--.*\.(?:aem|hlx)\.live/)) {
+    return new Response('Invalid ORIGIN_HOSTNAME', { status: 500 });
+  }
+  const req = new Request(url, request);
+  req.headers.set('x-forwarded-host', req.headers.get('host'));
+  req.headers.set('x-byo-cdn-type', 'cloudflare');
+  if (env.PUSH_INVALIDATION !== 'disabled') {
+    req.headers.set('x-push-invalidation', 'enabled');
+  }
+  if (env.ORIGIN_AUTHENTICATION) {
+    req.headers.set('authorization', `token ${env.ORIGIN_AUTHENTICATION}`);
+  }
+  let resp = await fetch(req, {
+    method: req.method,
+    cf: {
+      // cf doesn't cache html by default: need to override the default behavior
+      cacheEverything: true,
+    },
+  });
+  resp = new Response(resp.body, resp);
+  if (resp.status === 301 && savedSearch) {
+    const location = resp.headers.get('location');
+    if (location && !location.match(/\?.*$/)) {
+      resp.headers.set('location', `${location}${savedSearch}`);
+    }
+  }
+  if (resp.status === 304) {
+    // 304 Not Modified - remove CSP header
+    resp.headers.delete('Content-Security-Policy');
+  }
+  resp.headers.delete('age');
+  resp.headers.delete('x-robots-tag');
+  return resp;
+};
+
+export default {
+  fetch: handleRequest,
+};


### PR DESCRIPTION
## Summary

- Adds Terraform (OpenTofu) config to manage Cloudflare zone for `mostly-hallucinations.com` as BYO CDN in front of AEM Edge Delivery Services
- Deploys Adobe's [aem-cloudflare-prod-worker](https://github.com/adobe/aem-cloudflare-prod-worker) with `www → apex` 301 redirect baked in
- Configures DNS (apex + www CNAME, proxied), SSL (Full mode), TLS 1.2+ with 1.3 ZRT, HTTPS rewrites, and origin-respecting cache TTLs
- Push invalidation registered with Adobe admin API

**Infrastructure is already live and verified.**

## Test URLs

- Site: https://mostly-hallucinations.com/
- www redirect: https://www.mostly-hallucinations.com/ (301 → apex)
- EDS origin: https://main--grounded--benpeter.aem.live/

## What's managed by Terraform

| Resource | Count |
|----------|-------|
| DNS records (apex + www CNAME) | 2 |
| Zone settings (SSL, TLS, cache, HTTPS) | 6 |
| Worker script + routes | 3 |

## What's NOT in Terraform

- Zone creation (one-time dashboard action, then read via `data` source)
- Nameserver delegation (dd24 registrar)
- Push invalidation registration (Adobe admin API)
- Redirect rule (handled in Worker instead of Cloudflare Ruleset — avoids permission gaps in scoped API tokens)

## Test plan

- [x] `curl -sI https://mostly-hallucinations.com/` returns 200 with `cf-ray` header
- [x] `curl -sI https://www.mostly-hallucinations.com/` returns 301 to apex
- [x] Second request shows `cf-cache-status: HIT`
- [x] `tofu plan` shows no changes (state matches live infra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)