### PR TITLE
fix: add noreferrer to footer external link

### DIFF
--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -9,7 +9,7 @@ export default function decorate(block) {
   const author = document.createElement('a');
   author.href = 'https://www.linkedin.com/in/benpeter/';
   author.target = '_blank';
-  author.rel = 'noopener';
+  author.rel = 'noopener noreferrer';
   author.setAttribute('aria-label', 'Ben Peter on LinkedIn (opens in new tab)');
   author.textContent = 'Ben Peter';
 


### PR DESCRIPTION
## Summary
- Add `noreferrer` to the LinkedIn link's `rel` attribute in `footer.js` (was `noopener` only)
- Per EDS security best practices for external links

## Test plan
- [x] Verify `rel="noopener noreferrer"` is set on the author link
- Code-only change — no visual difference, no preview URL needed