### PR TITLE
fix: use design token for cards border color

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -8,7 +8,7 @@
 }
 
 .cards > ul > li {
-  border: 1px solid #dadada;
+  border: 1px solid var(--color-border);
   background-color: var(--color-background);
 }
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `#dadada` with `var(--color-border)` in cards block
- Ensures consistency with the design system and proper dark mode adaptation

## Test URLs
- Before: https://main--grounded--benpeter.aem.live/
- After: https://fix-cards-design-token--grounded--benpeter.aem.live/

🤖 Generated with [Claude Code](https://claude.com/claude-code)